### PR TITLE
Feat UI theme start

### DIFF
--- a/TermProject/Assets/Scenes/UI/LobbyMenuScene.unity
+++ b/TermProject/Assets/Scenes/UI/LobbyMenuScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:24baa878309ce2ee1ee6a085e6d54207db29196e41da99a92008a66c66bd6337
-size 37734
+oid sha256:5d7474e69affb741064a27c3b8da439cc57608b8787a96a2fbdecb9f20a4dfdf
+size 37761

--- a/TermProject/Assets/Scenes/UI/LobbyMenuScene.unity
+++ b/TermProject/Assets/Scenes/UI/LobbyMenuScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d20d5833267398ca7e5d8731f6b49698a393b70b19213da67654a9d23bf852c9
-size 33862
+oid sha256:79b1c42cdac7dd153fd77367bcab1abdb8453ed38bfd0ad73664e6fed1bd0e8f
+size 26015

--- a/TermProject/Assets/Scenes/UI/LobbyMenuScene.unity
+++ b/TermProject/Assets/Scenes/UI/LobbyMenuScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5d7474e69affb741064a27c3b8da439cc57608b8787a96a2fbdecb9f20a4dfdf
-size 37761
+oid sha256:d20d5833267398ca7e5d8731f6b49698a393b70b19213da67654a9d23bf852c9
+size 33862

--- a/TermProject/Assets/Scenes/UI/MainMenuScene.unity
+++ b/TermProject/Assets/Scenes/UI/MainMenuScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2bb8fb56f84b93b15b7125367abd80f3386d01c673137567be43acdcb45b9ba5
-size 41247
+oid sha256:39ff77dcd0931dd9a821a39d529eaf7078f87115400cb09ac010c9d0115ef070
+size 41290

--- a/TermProject/Assets/Scenes/UI/MultiplayerMenuScene.unity
+++ b/TermProject/Assets/Scenes/UI/MultiplayerMenuScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2d65c9a2d52f31b372ea09731a74b04756bad5b48d25264a21987b0cb935aa0b
-size 71289
+oid sha256:e4423c414ddd62f90222d801897923cd286d1e1c4e9166081249dbda0c07dc4f
+size 71315

--- a/TermProject/Assets/Scenes/UI/SettingsMenuScene.unity
+++ b/TermProject/Assets/Scenes/UI/SettingsMenuScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a64a92f87a647ddc6b326d7dc2104fd2cb988bdca03f47dc28b4f5683cf25ce7
-size 43941
+oid sha256:59fe265d9952504b4f36c9075cded94a687897fd3bc56e2cdadcc6e07cc90c30
+size 44006

--- a/TermProject/Assets/Scenes/UI/StartMenuScene.unity
+++ b/TermProject/Assets/Scenes/UI/StartMenuScene.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:14297665739866be518425e193059b2f5e7865522077826c9ebc9f296c152f89
-size 24745
+oid sha256:b7f9ed74cfad8dde56de3b70c074bb51e4a9861f6b4dc25ee11fdd978316c102
+size 24810


### PR DESCRIPTION
# About
The background color of all pre-game scenes is dark blue. 
This also makes the built-in UI for mirror's lobby a lot more readable for now

## Testing this PR
1. Activate Start Menu scene and validate the background is dark blue
2. Navigate through Settings and Multiplayer and Lobby scene and validate the background is blue